### PR TITLE
improved the web request success handling.

### DIFF
--- a/DellOpenManage/Private/Get-ApiAllData.ps1
+++ b/DellOpenManage/Private/Get-ApiAllData.ps1
@@ -22,7 +22,7 @@ function Get-ApiAllData {
     $Data = @()
     $ContentType = "application/json"
     $Response = Invoke-WebRequest -UseBasicParsing -Uri $Url -Headers $Headers -Method Get
-    if ($Response.StatusCode -eq 200) {
+    if ($Response.StatusCode -in (200,201)) {
         $Info = $Response.Content | ConvertFrom-Json
         if ($Info.value) { 
             foreach ($Value in $Info.value) {
@@ -33,7 +33,7 @@ function Get-ApiAllData {
             }
             while($NextLinkUrl) {
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $ContentType
-                if($NextLinkResponse.StatusCode -eq 200)
+                if($NextLinkResponse.StatusCode -in (200,201))
                 {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     foreach ($NextLink in $NextLinkData.'value') {

--- a/DellOpenManage/Private/Wait-OnConfigurationBaseline.ps1
+++ b/DellOpenManage/Private/Wait-OnConfigurationBaseline.ps1
@@ -76,7 +76,7 @@ Process {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
         $BaselineResponse = Invoke-WebRequest -Uri $BaselineUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($BaselineResponse.StatusCode -eq 200) {
+        if ($BaselineResponse.StatusCode -in (200,201)) {
             $BaselineInfo = $BaselineResponse.Content | ConvertFrom-Json
             foreach ($Baseline in $BaselineInfo.'value') {
                 if ($Baseline.Id -eq $BaselineId) {

--- a/DellOpenManage/Private/Wait-OnFirmwareBaseline.ps1
+++ b/DellOpenManage/Private/Wait-OnFirmwareBaseline.ps1
@@ -76,7 +76,7 @@ Process {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
         $BaselineResponse = Invoke-WebRequest -Uri $BaselineUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($BaselineResponse.StatusCode -eq 200) {
+        if ($BaselineResponse.StatusCode -in (200,201)) {
             $BaselineInfo = $BaselineResponse.Content | ConvertFrom-Json
             foreach ($Baseline in $BaselineInfo.'value') {
                 if ($Baseline.Name -eq $BaselineName) {

--- a/DellOpenManage/Private/Wait-OnTemplate.ps1
+++ b/DellOpenManage/Private/Wait-OnTemplate.ps1
@@ -82,7 +82,7 @@ Process {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
         $TemplateResponse = Invoke-WebRequest -Uri $TemplateUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($TemplateResponse.StatusCode -eq 200) {
+        if ($TemplateResponse.StatusCode -in (200,201)) {
             $TemplateInfo = $TemplateResponse.Content | ConvertFrom-Json
             $Status = [int]$TemplateInfo.value[0].Status
             Write-Verbose "Iteration $($Ctr): Status of $($TemplateId) is $($JOB_STATUS_MAP.$Status)"

--- a/DellOpenManage/Public/OME/Connect-OMEServer.ps1
+++ b/DellOpenManage/Public/OME/Connect-OMEServer.ps1
@@ -80,7 +80,7 @@ param(
     $UserDetails = @{"UserName"=$OMEUserName;"Password"=$OMEPassword;"SessionType"="API"} | ConvertTo-Json
 
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -UseBasicParsing -Method Post -Body $UserDetails -ContentType $Type 
-    if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
+    if ($SessResponse.StatusCode -in (200,201) -or $SessResponse.StatusCode -eq 201) {
         $SessResponseData = $SessResponse.Content | ConvertFrom-Json
         
         $Token = [String]$SessResponse.Headers["X-Auth-Token"]

--- a/DellOpenManage/Public/OME/Connect-OMEServer.ps1
+++ b/DellOpenManage/Public/OME/Connect-OMEServer.ps1
@@ -80,7 +80,7 @@ param(
     $UserDetails = @{"UserName"=$OMEUserName;"Password"=$OMEPassword;"SessionType"="API"} | ConvertTo-Json
 
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -UseBasicParsing -Method Post -Body $UserDetails -ContentType $Type 
-    if ($SessResponse.StatusCode -in (200,201) -or $SessResponse.StatusCode -eq 201) {
+    if ($SessResponse.StatusCode -in 200, 201) {
         $SessResponseData = $SessResponse.Content | ConvertFrom-Json
         
         $Token = [String]$SessResponse.Headers["X-Auth-Token"]
@@ -91,7 +91,7 @@ param(
         $AppInfoUrl = "https://$($OMEHost)/api/ApplicationService/Info"
         $AppInfoResponse = Invoke-WebRequest -Uri $AppInfoUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type 
         $AppVersion = [System.Version]"1.0.0"
-        if ($AppInfoResponse.StatusCode -eq 200 -or $AppInfoResponse.StatusCode -eq 201) {
+        if ($AppInfoResponse.StatusCode -eq 200, 201) {
             $AppInfoResponseData = $AppInfoResponse.Content | ConvertFrom-Json
             Write-Verbose $($AppInfoResponseData)
             $AppVersion = [System.Version]$AppInfoResponseData.Version

--- a/DellOpenManage/Public/OME/Connect-OMEServer.ps1
+++ b/DellOpenManage/Public/OME/Connect-OMEServer.ps1
@@ -91,7 +91,7 @@ param(
         $AppInfoUrl = "https://$($OMEHost)/api/ApplicationService/Info"
         $AppInfoResponse = Invoke-WebRequest -Uri $AppInfoUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type 
         $AppVersion = [System.Version]"1.0.0"
-        if ($AppInfoResponse.StatusCode -eq 200, 201) {
+        if ($AppInfoResponse.StatusCode -in 200, 201) {
             $AppInfoResponseData = $AppInfoResponse.Content | ConvertFrom-Json
             Write-Verbose $($AppInfoResponseData)
             $AppVersion = [System.Version]$AppInfoResponseData.Version

--- a/DellOpenManage/Public/OME/Copy-OMETemplate.ps1
+++ b/DellOpenManage/Public/OME/Copy-OMETemplate.ps1
@@ -11,7 +11,7 @@ function Get-TemplateVlan($BaseUri, $ContentType, $Headers, $Template) {
     $NETWORK_HIERARCHY_VIEW = 4  # For Network hierarchy View in a Template
     $TemplateVlanUrl = $BaseUri + "/api/TemplateService/Templates($($Template.Id))/Views($($NETWORK_HIERARCHY_VIEW))/AttributeViewDetails"
     $TemplateVlanResponse = Invoke-WebRequest -Uri $TemplateVlanUrl -UseBasicParsing -Method Get -ContentType $ContentType -Headers $Headers
-    if ($TemplateVlanResponse.StatusCode -in (200,201)) {
+    if ($TemplateVlanResponse.StatusCode -in 200, 201) {
         $TemplateVlans = $TemplateVlanResponse.Content | ConvertFrom-Json
         $NICGroups = @()
         $NICBondingList = @()
@@ -188,7 +188,7 @@ Process {
         $NewTemplateId = $null
         Write-Verbose "Clone Template..."
         $TemplateResponse = Invoke-WebRequest -Uri $TemplateUrl -UseBasicParsing -Method Post -Body $TemplatePayload -ContentType $ContentType -Headers $Headers
-        if ($TemplateResponse.StatusCode -in (200,201)) {
+        if ($TemplateResponse.StatusCode -in 200, 201) {
             $NewTemplateId = [int]$TemplateResponse.Content
             Write-Verbose "Clone Template Success - Id $($NewTemplateId)"
         }
@@ -203,7 +203,7 @@ Process {
             Write-Verbose $CloneTemplateVlanPayload
             $TemplateUpdateNetworkUrl = $BaseUri + "/api/TemplateService/Actions/TemplateService.UpdateNetworkConfig"
             $TemplateVlanResponse = Invoke-WebRequest -Uri $TemplateUpdateNetworkUrl -UseBasicParsing -Method Post -Body $CloneTemplateVlanPayload -ContentType $ContentType -Headers $Headers
-            if ($TemplateVlanResponse.StatusCode -in (200,201)) {
+            if ($TemplateVlanResponse.StatusCode -in 200, 201) {
                 Write-Verbose "Clone Template Success - VLANs"
             }
         }

--- a/DellOpenManage/Public/OME/Copy-OMETemplate.ps1
+++ b/DellOpenManage/Public/OME/Copy-OMETemplate.ps1
@@ -11,7 +11,7 @@ function Get-TemplateVlan($BaseUri, $ContentType, $Headers, $Template) {
     $NETWORK_HIERARCHY_VIEW = 4  # For Network hierarchy View in a Template
     $TemplateVlanUrl = $BaseUri + "/api/TemplateService/Templates($($Template.Id))/Views($($NETWORK_HIERARCHY_VIEW))/AttributeViewDetails"
     $TemplateVlanResponse = Invoke-WebRequest -Uri $TemplateVlanUrl -UseBasicParsing -Method Get -ContentType $ContentType -Headers $Headers
-    if ($TemplateVlanResponse.StatusCode -eq 200) {
+    if ($TemplateVlanResponse.StatusCode -in (200,201)) {
         $TemplateVlans = $TemplateVlanResponse.Content | ConvertFrom-Json
         $NICGroups = @()
         $NICBondingList = @()
@@ -188,7 +188,7 @@ Process {
         $NewTemplateId = $null
         Write-Verbose "Clone Template..."
         $TemplateResponse = Invoke-WebRequest -Uri $TemplateUrl -UseBasicParsing -Method Post -Body $TemplatePayload -ContentType $ContentType -Headers $Headers
-        if ($TemplateResponse.StatusCode -eq 200) {
+        if ($TemplateResponse.StatusCode -in (200,201)) {
             $NewTemplateId = [int]$TemplateResponse.Content
             Write-Verbose "Clone Template Success - Id $($NewTemplateId)"
         }
@@ -203,7 +203,7 @@ Process {
             Write-Verbose $CloneTemplateVlanPayload
             $TemplateUpdateNetworkUrl = $BaseUri + "/api/TemplateService/Actions/TemplateService.UpdateNetworkConfig"
             $TemplateVlanResponse = Invoke-WebRequest -Uri $TemplateUpdateNetworkUrl -UseBasicParsing -Method Post -Body $CloneTemplateVlanPayload -ContentType $ContentType -Headers $Headers
-            if ($TemplateVlanResponse.StatusCode -eq 200) {
+            if ($TemplateVlanResponse.StatusCode -in (200,201)) {
                 Write-Verbose "Clone Template Success - VLANs"
             }
         }

--- a/DellOpenManage/Public/OME/Edit-OMEDiscovery.ps1
+++ b/DellOpenManage/Public/OME/Edit-OMEDiscovery.ps1
@@ -131,7 +131,7 @@ function Get-JobId($BaseUri, $Headers, $DiscoverConfigGroupId) {
     $JobId = -1
     $JobUrl = $BaseUri + "/api/DiscoveryConfigService/Jobs"
     $JobResponse = Invoke-WebRequest -UseBasicParsing -Uri $JobUrl -Headers $Headers -Method Get
-    if ($JobResponse.StatusCode -eq 200) {
+    if ($JobResponse.StatusCode -in (200,201)) {
         $JobInfo = $JobResponse.Content | ConvertFrom-Json
         $JobValues = $JobInfo.value
         foreach ($value in $JobValues) {
@@ -282,7 +282,7 @@ Process {
         $DiscoveryId = $Discovery.Id
         $DiscoverUrl = $BaseUri + "/api/DiscoveryConfigService/DiscoveryConfigGroups(" + $DiscoveryId + ")"
         $DiscoverResponse = Invoke-WebRequest -Uri $DiscoverUrl -UseBasicParsing -Method Put -Body $Payload -Headers $Headers -ContentType $Type
-        if ($DiscoverResponse.StatusCode -eq 200) {
+        if ($DiscoverResponse.StatusCode -in (200,201)) {
             Write-Verbose "Discovering devices...."
             Start-Sleep -Seconds 10
             $DiscoverInfo = $DiscoverResponse.Content | ConvertFrom-Json

--- a/DellOpenManage/Public/OME/Edit-OMEDiscovery.ps1
+++ b/DellOpenManage/Public/OME/Edit-OMEDiscovery.ps1
@@ -131,7 +131,7 @@ function Get-JobId($BaseUri, $Headers, $DiscoverConfigGroupId) {
     $JobId = -1
     $JobUrl = $BaseUri + "/api/DiscoveryConfigService/Jobs"
     $JobResponse = Invoke-WebRequest -UseBasicParsing -Uri $JobUrl -Headers $Headers -Method Get
-    if ($JobResponse.StatusCode -in (200,201)) {
+    if ($JobResponse.StatusCode -in 200, 201) {
         $JobInfo = $JobResponse.Content | ConvertFrom-Json
         $JobValues = $JobInfo.value
         foreach ($value in $JobValues) {
@@ -282,7 +282,7 @@ Process {
         $DiscoveryId = $Discovery.Id
         $DiscoverUrl = $BaseUri + "/api/DiscoveryConfigService/DiscoveryConfigGroups(" + $DiscoveryId + ")"
         $DiscoverResponse = Invoke-WebRequest -Uri $DiscoverUrl -UseBasicParsing -Method Put -Body $Payload -Headers $Headers -ContentType $Type
-        if ($DiscoverResponse.StatusCode -in (200,201)) {
+        if ($DiscoverResponse.StatusCode -in 200, 201) {
             Write-Verbose "Discovering devices...."
             Start-Sleep -Seconds 10
             $DiscoverInfo = $DiscoverResponse.Content | ConvertFrom-Json

--- a/DellOpenManage/Public/OME/Edit-OMEGroup.ps1
+++ b/DellOpenManage/Public/OME/Edit-OMEGroup.ps1
@@ -163,7 +163,7 @@ Process {
 
         $GroupResponse = Invoke-WebRequest -Uri $GroupURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $GroupPayload
         Write-Verbose "Updating group..."
-        if ($GroupResponse.StatusCode -in (200,201)) {
+        if ($GroupResponse.StatusCode -in 200, 201) {
             Write-Verbose "Group update successful!"
             return $GroupResponse.Content | ConvertFrom-Json
         }

--- a/DellOpenManage/Public/OME/Edit-OMEGroup.ps1
+++ b/DellOpenManage/Public/OME/Edit-OMEGroup.ps1
@@ -163,7 +163,7 @@ Process {
 
         $GroupResponse = Invoke-WebRequest -Uri $GroupURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $GroupPayload
         Write-Verbose "Updating group..."
-        if ($GroupResponse.StatusCode -eq 200) {
+        if ($GroupResponse.StatusCode -in (200,201)) {
             Write-Verbose "Group update successful!"
             return $GroupResponse.Content | ConvertFrom-Json
         }

--- a/DellOpenManage/Public/OME/Edit-OMESecurityBanner.ps1
+++ b/DellOpenManage/Public/OME/Edit-OMESecurityBanner.ps1
@@ -58,7 +58,7 @@ Process {
         Write-Verbose $BannerPayload
         $BannerResponse = Invoke-WebRequest -Uri $BannerURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $BannerPayload
         Write-Verbose "Updating banner text..."
-        if ($BannerResponse.StatusCode -in (200,201)) {
+        if ($BannerResponse.StatusCode -in 200, 201) {
             Write-Verbose "Banner update successfull!"
             return $true
         }

--- a/DellOpenManage/Public/OME/Edit-OMESecurityBanner.ps1
+++ b/DellOpenManage/Public/OME/Edit-OMESecurityBanner.ps1
@@ -58,7 +58,7 @@ Process {
         Write-Verbose $BannerPayload
         $BannerResponse = Invoke-WebRequest -Uri $BannerURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $BannerPayload
         Write-Verbose "Updating banner text..."
-        if ($BannerResponse.StatusCode -eq 200) {
+        if ($BannerResponse.StatusCode -in (200,201)) {
             Write-Verbose "Banner update successfull!"
             return $true
         }

--- a/DellOpenManage/Public/OME/Get-OMEAlertDefinition.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEAlertDefinition.ps1
@@ -56,7 +56,7 @@ Process {
 
         $DefinitionCountUrl = $BaseUri + "/api/AlertService/AlertMessageDefinitions"
         $DeviceResponse = Invoke-WebRequest -Uri $DefinitionCountUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($DeviceResponse.StatusCode -in (200,201))
+        if ($DeviceResponse.StatusCode -in 200, 201)
         {
             $DefinitionCountData = $DeviceResponse.Content | ConvertFrom-Json
             foreach ($Definition in $DefinitionCountData.'value') {
@@ -69,7 +69,7 @@ Process {
             while($NextLinkUrl)
             {
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -in (200,201))
+                if($NextLinkResponse.StatusCode -in 200, 201)
                 {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     foreach ($Definition in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEAlertDefinition.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEAlertDefinition.ps1
@@ -56,7 +56,7 @@ Process {
 
         $DefinitionCountUrl = $BaseUri + "/api/AlertService/AlertMessageDefinitions"
         $DeviceResponse = Invoke-WebRequest -Uri $DefinitionCountUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($DeviceResponse.StatusCode -eq 200)
+        if ($DeviceResponse.StatusCode -in (200,201))
         {
             $DefinitionCountData = $DeviceResponse.Content | ConvertFrom-Json
             foreach ($Definition in $DefinitionCountData.'value') {
@@ -69,7 +69,7 @@ Process {
             while($NextLinkUrl)
             {
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -eq 200)
+                if($NextLinkResponse.StatusCode -in (200,201))
                 {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     foreach ($Definition in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEAlertPolicy.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEAlertPolicy.ps1
@@ -79,7 +79,7 @@ Process {
         }
         Write-Verbose $AlertPolicyUrl
         $AlertPolicyResponse = Invoke-WebRequest -Uri $AlertPolicyUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($AlertPolicyResponse.StatusCode -in (200,201))
+        if ($AlertPolicyResponse.StatusCode -in 200, 201)
         {
             $AlertPolicyCountData = $AlertPolicyResponse.Content | ConvertFrom-Json
             foreach ($AlertPolicy in $AlertPolicyCountData.'value') {
@@ -94,7 +94,7 @@ Process {
             {
                 Write-Verbose $NextLinkUrl
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -in (200,201))
+                if($NextLinkResponse.StatusCode -in 200, 201)
                 {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     foreach ($AlertPolicy in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEAlertPolicy.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEAlertPolicy.ps1
@@ -79,7 +79,7 @@ Process {
         }
         Write-Verbose $AlertPolicyUrl
         $AlertPolicyResponse = Invoke-WebRequest -Uri $AlertPolicyUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($AlertPolicyResponse.StatusCode -eq 200)
+        if ($AlertPolicyResponse.StatusCode -in (200,201))
         {
             $AlertPolicyCountData = $AlertPolicyResponse.Content | ConvertFrom-Json
             foreach ($AlertPolicy in $AlertPolicyCountData.'value') {
@@ -94,7 +94,7 @@ Process {
             {
                 Write-Verbose $NextLinkUrl
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -eq 200)
+                if($NextLinkResponse.StatusCode -in (200,201))
                 {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     foreach ($AlertPolicy in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEApplicationSettings.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEApplicationSettings.ps1
@@ -45,7 +45,7 @@ limitations under the License.
 
             $JobURL = $BaseUri + "/api/ApplicationService/Actions/ApplicationService.GetConfiguration"
             $JobResp = Invoke-WebRequest -Uri $JobURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $null
-            if ($JobResp.StatusCode -eq 200) {
+            if ($JobResp.StatusCode -in (200,201)) {
                 Write-Verbose "Application settings job submitted successful..."
                 $JobInfo = $JobResp.Content | ConvertFrom-Json
                 $JobInfo

--- a/DellOpenManage/Public/OME/Get-OMEApplicationSettings.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEApplicationSettings.ps1
@@ -45,7 +45,7 @@ limitations under the License.
 
             $JobURL = $BaseUri + "/api/ApplicationService/Actions/ApplicationService.GetConfiguration"
             $JobResp = Invoke-WebRequest -Uri $JobURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $null
-            if ($JobResp.StatusCode -in (200,201)) {
+            if ($JobResp.StatusCode -in 200, 201) {
                 Write-Verbose "Application settings job submitted successful..."
                 $JobInfo = $JobResp.Content | ConvertFrom-Json
                 $JobInfo

--- a/DellOpenManage/Public/OME/Get-OMECatalog.ps1
+++ b/DellOpenManage/Public/OME/Get-OMECatalog.ps1
@@ -63,7 +63,7 @@ Process {
 
         $CatalogData = @()
         $CatalogResp = Invoke-WebRequest -Uri $CatalogUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($CatalogResp.StatusCode -eq 200) {
+        if ($CatalogResp.StatusCode -in (200,201)) {
             $CatalogInfo = $CatalogResp.Content | ConvertFrom-Json
             foreach ($Catalog in $CatalogInfo.'value') {
                 if ($Value.Count -gt 0 -and $FilterBy -eq "Id") {

--- a/DellOpenManage/Public/OME/Get-OMECatalog.ps1
+++ b/DellOpenManage/Public/OME/Get-OMECatalog.ps1
@@ -63,7 +63,7 @@ Process {
 
         $CatalogData = @()
         $CatalogResp = Invoke-WebRequest -Uri $CatalogUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($CatalogResp.StatusCode -in (200,201)) {
+        if ($CatalogResp.StatusCode -in 200, 201) {
             $CatalogInfo = $CatalogResp.Content | ConvertFrom-Json
             foreach ($Catalog in $CatalogInfo.'value') {
                 if ($Value.Count -gt 0 -and $FilterBy -eq "Id") {

--- a/DellOpenManage/Public/OME/Get-OMEConfigurationBaseline.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEConfigurationBaseline.ps1
@@ -63,7 +63,7 @@ Process {
 
         $BaselineData = @()
         $BaselineResp = Invoke-WebRequest -Uri $BaselineUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($BaselineResp.StatusCode -in (200,201)) {
+        if ($BaselineResp.StatusCode -in 200, 201) {
             $BaselineInfo = $BaselineResp.Content | ConvertFrom-Json
             foreach ($Baseline in $BaselineInfo.'value') {
                 if ($Value.Count -gt 0 -and $FilterBy -eq "Id") {

--- a/DellOpenManage/Public/OME/Get-OMEConfigurationBaseline.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEConfigurationBaseline.ps1
@@ -63,7 +63,7 @@ Process {
 
         $BaselineData = @()
         $BaselineResp = Invoke-WebRequest -Uri $BaselineUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($BaselineResp.StatusCode -eq 200) {
+        if ($BaselineResp.StatusCode -in (200,201)) {
             $BaselineInfo = $BaselineResp.Content | ConvertFrom-Json
             foreach ($Baseline in $BaselineInfo.'value') {
                 if ($Value.Count -gt 0 -and $FilterBy -eq "Id") {

--- a/DellOpenManage/Public/OME/Get-OMEConfigurationCompliance.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEConfigurationCompliance.ps1
@@ -82,7 +82,7 @@ Process {
         #    2 = "Not Compliant"
         #}
 
-        if ($Response.StatusCode -eq 200) {
+        if ($Response.StatusCode -in (200,201)) {
             $ComplData = $Response | ConvertFrom-Json
             $ComplianceDeviceList = $ComplData.'value'
 
@@ -92,7 +92,7 @@ Process {
             while($NextLinkUrl)
             {
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method GET -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -eq 200) {
+                if($NextLinkResponse.StatusCode -in (200,201)) {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     $ComplianceDeviceList = $ComplianceDeviceList + $NextLinkData.'value'
                     if($NextLinkData.'@odata.nextLink')

--- a/DellOpenManage/Public/OME/Get-OMEConfigurationCompliance.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEConfigurationCompliance.ps1
@@ -82,7 +82,7 @@ Process {
         #    2 = "Not Compliant"
         #}
 
-        if ($Response.StatusCode -in (200,201)) {
+        if ($Response.StatusCode -in 200, 201) {
             $ComplData = $Response | ConvertFrom-Json
             $ComplianceDeviceList = $ComplData.'value'
 
@@ -92,7 +92,7 @@ Process {
             while($NextLinkUrl)
             {
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method GET -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -in (200,201)) {
+                if($NextLinkResponse.StatusCode -in 200, 201) {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     $ComplianceDeviceList = $ComplianceDeviceList + $NextLinkData.'value'
                     if($NextLinkData.'@odata.nextLink')

--- a/DellOpenManage/Public/OME/Get-OMEDevice.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEDevice.ps1
@@ -114,7 +114,7 @@ Process {
             $GroupUrl = "https://$($SessionAuth.Host)/api/GroupService/Groups"
             $GroupUrl += "(" + [String]($Group.Id) + ")/Devices"
             $GroupResp = Invoke-WebRequest -Uri $GroupUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-            if ($GroupResp.StatusCode -in (200,201)) {
+            if ($GroupResp.StatusCode -in 200, 201) {
                 $GroupInfo = $GroupResp.Content | ConvertFrom-Json
                 $GroupData = $GroupInfo.'value'
                 $DeviceCount = $GroupInfo.'@odata.count'
@@ -127,7 +127,7 @@ Process {
                         $delta = $DeviceCount-$currDeviceCount 
                         $RemainingDeviceUrl = $GroupUrl+"?`$skip=$($currDeviceCount)&`$top=$($delta)"
                         $RemainingDeviceResp = Invoke-WebRequest -Uri $RemainingDeviceUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                        if($RemainingDeviceResp.StatusCode -in (200,201)){
+                        if($RemainingDeviceResp.StatusCode -in 200, 201){
                             $RemainingDeviceInfo = $RemainingDeviceResp.Content | ConvertFrom-Json
                             foreach ($Device in $RemainingDeviceInfo.'value') {
                                 $DeviceData += New-DeviceFromJson -Device $Device
@@ -157,7 +157,7 @@ Process {
             $DeviceCountUrl = $DeviceCountUrl + "?" + $Filter
             Write-Verbose $DeviceCountUrl
             $DeviceResponse = Invoke-WebRequest -Uri $DeviceCountUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-            if ($DeviceResponse.StatusCode -in (200,201))
+            if ($DeviceResponse.StatusCode -in 200, 201)
             {
                 $DeviceCountData = $DeviceResponse.Content | ConvertFrom-Json
                 foreach ($Device in $DeviceCountData.'value') {
@@ -171,7 +171,7 @@ Process {
                 {
                     Write-Verbose $NextLinkUrl
                     $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                    if($NextLinkResponse.StatusCode -in (200,201))
+                    if($NextLinkResponse.StatusCode -in 200, 201)
                     {
                         $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                         foreach ($Device in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEDevice.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEDevice.ps1
@@ -114,7 +114,7 @@ Process {
             $GroupUrl = "https://$($SessionAuth.Host)/api/GroupService/Groups"
             $GroupUrl += "(" + [String]($Group.Id) + ")/Devices"
             $GroupResp = Invoke-WebRequest -Uri $GroupUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-            if ($GroupResp.StatusCode -eq 200) {
+            if ($GroupResp.StatusCode -in (200,201)) {
                 $GroupInfo = $GroupResp.Content | ConvertFrom-Json
                 $GroupData = $GroupInfo.'value'
                 $DeviceCount = $GroupInfo.'@odata.count'
@@ -127,7 +127,7 @@ Process {
                         $delta = $DeviceCount-$currDeviceCount 
                         $RemainingDeviceUrl = $GroupUrl+"?`$skip=$($currDeviceCount)&`$top=$($delta)"
                         $RemainingDeviceResp = Invoke-WebRequest -Uri $RemainingDeviceUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                        if($RemainingDeviceResp.StatusCode -eq 200){
+                        if($RemainingDeviceResp.StatusCode -in (200,201)){
                             $RemainingDeviceInfo = $RemainingDeviceResp.Content | ConvertFrom-Json
                             foreach ($Device in $RemainingDeviceInfo.'value') {
                                 $DeviceData += New-DeviceFromJson -Device $Device
@@ -157,7 +157,7 @@ Process {
             $DeviceCountUrl = $DeviceCountUrl + "?" + $Filter
             Write-Verbose $DeviceCountUrl
             $DeviceResponse = Invoke-WebRequest -Uri $DeviceCountUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-            if ($DeviceResponse.StatusCode -eq 200)
+            if ($DeviceResponse.StatusCode -in (200,201))
             {
                 $DeviceCountData = $DeviceResponse.Content | ConvertFrom-Json
                 foreach ($Device in $DeviceCountData.'value') {
@@ -171,7 +171,7 @@ Process {
                 {
                     Write-Verbose $NextLinkUrl
                     $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                    if($NextLinkResponse.StatusCode -eq 200)
+                    if($NextLinkResponse.StatusCode -in (200,201))
                     {
                         $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                         foreach ($Device in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEDeviceDetail.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEDeviceDetail.ps1
@@ -66,7 +66,7 @@ Process {
             $InventoryUrl =  $BaseUri + "/api/DeviceService/Devices($($Devices.Id))/InventoryDetails('$($InventoryType)')"
         }
         $InventoryResp = Invoke-WebRequest -Uri $InventoryUrl -UseBasicParsing -Headers $Headers -Method Get -ContentType $Type
-        if ($InventoryResp.StatusCode -eq 200) {
+        if ($InventoryResp.StatusCode -in (200,201)) {
             $InventoryInfo = $InventoryResp.Content | ConvertFrom-Json
             if ($InventoryInfo.'value') {
                 $InventoryData = $InventoryInfo.'value'

--- a/DellOpenManage/Public/OME/Get-OMEDeviceDetail.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEDeviceDetail.ps1
@@ -66,7 +66,7 @@ Process {
             $InventoryUrl =  $BaseUri + "/api/DeviceService/Devices($($Devices.Id))/InventoryDetails('$($InventoryType)')"
         }
         $InventoryResp = Invoke-WebRequest -Uri $InventoryUrl -UseBasicParsing -Headers $Headers -Method Get -ContentType $Type
-        if ($InventoryResp.StatusCode -in (200,201)) {
+        if ($InventoryResp.StatusCode -in 200, 201) {
             $InventoryInfo = $InventoryResp.Content | ConvertFrom-Json
             if ($InventoryInfo.'value') {
                 $InventoryData = $InventoryInfo.'value'

--- a/DellOpenManage/Public/OME/Get-OMEDiscovery.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEDiscovery.ps1
@@ -63,7 +63,7 @@ Process {
 
         $DiscoveryData = @()
         $DiscoveryResp = Invoke-WebRequest -Uri $DiscoveryUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($DiscoveryResp.StatusCode -eq 200) {
+        if ($DiscoveryResp.StatusCode -in (200,201)) {
             $DiscoveryInfo = $DiscoveryResp.Content | ConvertFrom-Json
             foreach ($Discovery in $DiscoveryInfo.'value') {
                 if ($Value.Count -gt 0 -and $FilterBy -eq "Id") {

--- a/DellOpenManage/Public/OME/Get-OMEDiscovery.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEDiscovery.ps1
@@ -63,7 +63,7 @@ Process {
 
         $DiscoveryData = @()
         $DiscoveryResp = Invoke-WebRequest -Uri $DiscoveryUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($DiscoveryResp.StatusCode -in (200,201)) {
+        if ($DiscoveryResp.StatusCode -in 200, 201) {
             $DiscoveryInfo = $DiscoveryResp.Content | ConvertFrom-Json
             foreach ($Discovery in $DiscoveryInfo.'value') {
                 if ($Value.Count -gt 0 -and $FilterBy -eq "Id") {

--- a/DellOpenManage/Public/OME/Get-OMEFirmwareBaseline.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEFirmwareBaseline.ps1
@@ -64,7 +64,7 @@ Process {
 
         $BaselineData = @()
         $BaselineResp = Invoke-WebRequest -Uri $BaselineUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($BaselineResp.StatusCode -in (200,201)) {
+        if ($BaselineResp.StatusCode -in 200, 201) {
             $BaselineInfo = $BaselineResp.Content | ConvertFrom-Json
             foreach ($Baseline in $BaselineInfo.'value') {
                 if ($Value.Count -gt 0 -and $FilterBy -eq "Id") {

--- a/DellOpenManage/Public/OME/Get-OMEFirmwareBaseline.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEFirmwareBaseline.ps1
@@ -64,7 +64,7 @@ Process {
 
         $BaselineData = @()
         $BaselineResp = Invoke-WebRequest -Uri $BaselineUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($BaselineResp.StatusCode -eq 200) {
+        if ($BaselineResp.StatusCode -in (200,201)) {
             $BaselineInfo = $BaselineResp.Content | ConvertFrom-Json
             foreach ($Baseline in $BaselineInfo.'value') {
                 if ($Value.Count -gt 0 -and $FilterBy -eq "Id") {

--- a/DellOpenManage/Public/OME/Get-OMEFirmwareCompliance.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEFirmwareCompliance.ps1
@@ -137,7 +137,7 @@ Process {
             $UpdateActionSet += $UpdateAction
         }
 
-        if ($Response.StatusCode -eq 200) {
+        if ($Response.StatusCode -in (200,201)) {
             $ComplData = $Response | ConvertFrom-Json
             $ComplianceDeviceList = $ComplData.'value'
 
@@ -147,7 +147,7 @@ Process {
             while($NextLinkUrl)
             {
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method GET -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -eq 200) {
+                if($NextLinkResponse.StatusCode -in (200,201)) {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     $ComplianceDeviceList = $ComplianceDeviceList + $NextLinkData.'value'
                     if($NextLinkData.'@odata.nextLink')

--- a/DellOpenManage/Public/OME/Get-OMEFirmwareCompliance.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEFirmwareCompliance.ps1
@@ -137,7 +137,7 @@ Process {
             $UpdateActionSet += $UpdateAction
         }
 
-        if ($Response.StatusCode -in (200,201)) {
+        if ($Response.StatusCode -in 200, 201) {
             $ComplData = $Response | ConvertFrom-Json
             $ComplianceDeviceList = $ComplData.'value'
 
@@ -147,7 +147,7 @@ Process {
             while($NextLinkUrl)
             {
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method GET -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -in (200,201)) {
+                if($NextLinkResponse.StatusCode -in 200, 201) {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     $ComplianceDeviceList = $ComplianceDeviceList + $NextLinkData.'value'
                     if($NextLinkData.'@odata.nextLink')

--- a/DellOpenManage/Public/OME/Get-OMEGroup.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEGroup.ps1
@@ -77,7 +77,7 @@ Process {
         $GroupUrl = $GroupUrl + "?" + $Filter
         Write-Verbose $GroupUrl
         $GrpResp = Invoke-WebRequest -Uri $GroupUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($GrpResp.StatusCode -eq 200) {
+        if ($GrpResp.StatusCode -in (200,201)) {
             $GroupInfo = $GrpResp.Content | ConvertFrom-Json
             foreach ($Group in $GroupInfo.'value') {
                 $GroupData += New-GroupFromJson $Group
@@ -90,7 +90,7 @@ Process {
             {
                 Write-Verbose $NextLinkUrl
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -eq 200)
+                if($NextLinkResponse.StatusCode -in (200,201))
                 {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     foreach ($Group in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEGroup.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEGroup.ps1
@@ -77,7 +77,7 @@ Process {
         $GroupUrl = $GroupUrl + "?" + $Filter
         Write-Verbose $GroupUrl
         $GrpResp = Invoke-WebRequest -Uri $GroupUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($GrpResp.StatusCode -in (200,201)) {
+        if ($GrpResp.StatusCode -in 200, 201) {
             $GroupInfo = $GrpResp.Content | ConvertFrom-Json
             foreach ($Group in $GroupInfo.'value') {
                 $GroupData += New-GroupFromJson $Group
@@ -90,7 +90,7 @@ Process {
             {
                 Write-Verbose $NextLinkUrl
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -in (200,201))
+                if($NextLinkResponse.StatusCode -in 200, 201)
                 {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     foreach ($Group in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEIdentityPoolUsage.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEIdentityPoolUsage.ps1
@@ -66,7 +66,7 @@ Process {
         # Get Identity Pool Usage Sets
         $IdentityPoolUsageSetUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets"
         $IdentityPoolUsageSetResp = Invoke-WebRequest -Uri $IdentityPoolUsageSetUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($IdentityPoolUsageSetResp.StatusCode -in (200,201)) {
+        if ($IdentityPoolUsageSetResp.StatusCode -in 200, 201) {
             $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetResp.Content | ConvertFrom-Json
             $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetRespData.'value'
 
@@ -78,7 +78,7 @@ Process {
 
                 $IdentityPoolUsageDetailUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets($($IdentitySetId))/Details"
                 $IdentityPoolUsageDetailResp = Invoke-WebRequest -Uri $IdentityPoolUsageDetailUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if ($IdentityPoolUsageDetailResp.StatusCode -in (200,201)) {
+                if ($IdentityPoolUsageDetailResp.StatusCode -in 200, 201) {
                     $IdentityPoolUsageDetailData = $IdentityPoolUsageDetailResp.Content | ConvertFrom-Json
                     # Loop through Details appending to object array
                     foreach ($DeviceEntry in $IdentityPoolUsageDetailData.'value') {
@@ -100,7 +100,7 @@ Process {
                     # Loop through pages until end
                     while ($NextLinkUrl) {
                         $IdentityPoolUsageDetailNextLinkResp = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                        if ($IdentityPoolUsageDetailNextLinkResp.StatusCode -in (200,201)) {
+                        if ($IdentityPoolUsageDetailNextLinkResp.StatusCode -in 200, 201) {
                             $IdentityPoolUsageDetailNextLinkData = $IdentityPoolUsageDetailNextLinkResp.Content | ConvertFrom-Json
                             # Loop through Details appending to object array
                             foreach ($DeviceEntry in $IdentityPoolUsageDetailNextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEIdentityPoolUsage.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEIdentityPoolUsage.ps1
@@ -66,7 +66,7 @@ Process {
         # Get Identity Pool Usage Sets
         $IdentityPoolUsageSetUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets"
         $IdentityPoolUsageSetResp = Invoke-WebRequest -Uri $IdentityPoolUsageSetUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($IdentityPoolUsageSetResp.StatusCode -eq 200) {
+        if ($IdentityPoolUsageSetResp.StatusCode -in (200,201)) {
             $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetResp.Content | ConvertFrom-Json
             $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetRespData.'value'
 
@@ -78,7 +78,7 @@ Process {
 
                 $IdentityPoolUsageDetailUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets($($IdentitySetId))/Details"
                 $IdentityPoolUsageDetailResp = Invoke-WebRequest -Uri $IdentityPoolUsageDetailUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if ($IdentityPoolUsageDetailResp.StatusCode -eq 200) {
+                if ($IdentityPoolUsageDetailResp.StatusCode -in (200,201)) {
                     $IdentityPoolUsageDetailData = $IdentityPoolUsageDetailResp.Content | ConvertFrom-Json
                     # Loop through Details appending to object array
                     foreach ($DeviceEntry in $IdentityPoolUsageDetailData.'value') {
@@ -100,7 +100,7 @@ Process {
                     # Loop through pages until end
                     while ($NextLinkUrl) {
                         $IdentityPoolUsageDetailNextLinkResp = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                        if ($IdentityPoolUsageDetailNextLinkResp.StatusCode -eq 200) {
+                        if ($IdentityPoolUsageDetailNextLinkResp.StatusCode -in (200,201)) {
                             $IdentityPoolUsageDetailNextLinkData = $IdentityPoolUsageDetailNextLinkResp.Content | ConvertFrom-Json
                             # Loop through Details appending to object array
                             foreach ($DeviceEntry in $IdentityPoolUsageDetailNextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEJob.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEJob.ps1
@@ -2,13 +2,13 @@
     $JobExecUrl = $BaseUri  + "/api/JobService/Jobs($JobId)/ExecutionHistories"
     $ExecResp = Invoke-WebRequest -UseBasicParsing -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
     $HistoryDetails = @()
-    if ($ExecResp.StatusCode -eq 200) {
+    if ($ExecResp.StatusCode -in (200,201)) {
         $ExecRespInfo = $ExecResp.Content | ConvertFrom-Json
         foreach ($ExecRespValue in $ExecRespInfo.value) {
             $HistoryId = $ExecRespValue.Id
             $ExecHistoryUrl = "$($JobExecUrl)($($HistoryId))/ExecutionHistoryDetails"
             $HistoryResp = Invoke-WebRequest -UseBasicParsing -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
-            if ($HistoryResp.StatusCode -eq 200) {
+            if ($HistoryResp.StatusCode -in (200,201)) {
                 $HistoryData = $HistoryResp.Content | ConvertFrom-Json
                 foreach ($HistoryDetail in $HistoryData.value) {
                     $HistoryDetails += $HistoryDetail
@@ -123,7 +123,7 @@ Process {
 
         $JobData = @()
         $JobResponse = Invoke-WebRequest -UseBasicParsing -Uri $JobUrl -Headers $Headers -Method Get -ContentType $Type
-        if ($JobResponse.StatusCode -eq 200) {
+        if ($JobResponse.StatusCode -in (200,201)) {
             $JobInfo = $JobResponse.Content | ConvertFrom-Json
             if ($JobInfo.value) { # Multiple jobs returned
                 foreach ($JobValue in $JobInfo.value) {
@@ -139,7 +139,7 @@ Process {
                 }
                 while($NextLinkUrl) {
                     $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                    if($NextLinkResponse.StatusCode -eq 200)
+                    if($NextLinkResponse.StatusCode -in (200,201))
                     {
                         $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                         foreach ($NextLinkJob in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEJob.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEJob.ps1
@@ -2,13 +2,13 @@
     $JobExecUrl = $BaseUri  + "/api/JobService/Jobs($JobId)/ExecutionHistories"
     $ExecResp = Invoke-WebRequest -UseBasicParsing -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
     $HistoryDetails = @()
-    if ($ExecResp.StatusCode -in (200,201)) {
+    if ($ExecResp.StatusCode -in 200, 201) {
         $ExecRespInfo = $ExecResp.Content | ConvertFrom-Json
         foreach ($ExecRespValue in $ExecRespInfo.value) {
             $HistoryId = $ExecRespValue.Id
             $ExecHistoryUrl = "$($JobExecUrl)($($HistoryId))/ExecutionHistoryDetails"
             $HistoryResp = Invoke-WebRequest -UseBasicParsing -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
-            if ($HistoryResp.StatusCode -in (200,201)) {
+            if ($HistoryResp.StatusCode -in 200, 201) {
                 $HistoryData = $HistoryResp.Content | ConvertFrom-Json
                 foreach ($HistoryDetail in $HistoryData.value) {
                     $HistoryDetails += $HistoryDetail
@@ -123,7 +123,7 @@ Process {
 
         $JobData = @()
         $JobResponse = Invoke-WebRequest -UseBasicParsing -Uri $JobUrl -Headers $Headers -Method Get -ContentType $Type
-        if ($JobResponse.StatusCode -in (200,201)) {
+        if ($JobResponse.StatusCode -in 200, 201) {
             $JobInfo = $JobResponse.Content | ConvertFrom-Json
             if ($JobInfo.value) { # Multiple jobs returned
                 foreach ($JobValue in $JobInfo.value) {
@@ -139,7 +139,7 @@ Process {
                 }
                 while($NextLinkUrl) {
                     $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                    if($NextLinkResponse.StatusCode -in (200,201))
+                    if($NextLinkResponse.StatusCode -in 200, 201)
                     {
                         $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                         foreach ($NextLinkJob in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEMXDomain.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEMXDomain.ps1
@@ -60,7 +60,7 @@ Process {
         $URL = $BaseUri + "/api/ManagementDomainService/Domains"
         $ContentType = "application/json"
         $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method GET
-        if ($Response.StatusCode -in (200,201)) {
+        if ($Response.StatusCode -in 200, 201) {
             $DomainResp = $Response.Content | ConvertFrom-Json
             if ($DomainResp."value".Length -gt 0) {
                 $MemberDevices = $DomainResp."value"

--- a/DellOpenManage/Public/OME/Get-OMEMXDomain.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEMXDomain.ps1
@@ -60,7 +60,7 @@ Process {
         $URL = $BaseUri + "/api/ManagementDomainService/Domains"
         $ContentType = "application/json"
         $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method GET
-        if ($Response.StatusCode -eq 200) {
+        if ($Response.StatusCode -in (200,201)) {
             $DomainResp = $Response.Content | ConvertFrom-Json
             if ($DomainResp."value".Length -gt 0) {
                 $MemberDevices = $DomainResp."value"

--- a/DellOpenManage/Public/OME/Get-OMEProfile.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEProfile.ps1
@@ -89,7 +89,7 @@ Process {
         $ProfileCountUrl = $ProfileCountUrl + "?" + $Filter
         Write-Verbose $ProfileCountUrl
         $ProfileResponse = Invoke-WebRequest -Uri $ProfileCountUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($ProfileResponse.StatusCode -eq 200)
+        if ($ProfileResponse.StatusCode -in (200,201))
         {
             $ProfileCountData = $ProfileResponse.Content | ConvertFrom-Json
             foreach ($ServerProfile in $ProfileCountData.'value') {
@@ -103,7 +103,7 @@ Process {
             {
                 Write-Verbose $NextLinkUrl
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -eq 200)
+                if($NextLinkResponse.StatusCode -in (200,201))
                 {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     foreach ($ServerProfile in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEProfile.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEProfile.ps1
@@ -89,7 +89,7 @@ Process {
         $ProfileCountUrl = $ProfileCountUrl + "?" + $Filter
         Write-Verbose $ProfileCountUrl
         $ProfileResponse = Invoke-WebRequest -Uri $ProfileCountUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($ProfileResponse.StatusCode -in (200,201))
+        if ($ProfileResponse.StatusCode -in 200, 201)
         {
             $ProfileCountData = $ProfileResponse.Content | ConvertFrom-Json
             foreach ($ServerProfile in $ProfileCountData.'value') {
@@ -103,7 +103,7 @@ Process {
             {
                 Write-Verbose $NextLinkUrl
                 $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if($NextLinkResponse.StatusCode -in (200,201))
+                if($NextLinkResponse.StatusCode -in 200, 201)
                 {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     foreach ($ServerProfile in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMESupportAssistGroup.ps1
+++ b/DellOpenManage/Public/OME/Get-OMESupportAssistGroup.ps1
@@ -62,7 +62,7 @@ Process {
 
         $GroupData = @()
         $GrpResp = Invoke-WebRequest -Uri $GroupUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $ContentType
-        if ($GrpResp.StatusCode -in (200,201)) {
+        if ($GrpResp.StatusCode -in 200, 201) {
             $GroupData = $GrpResp.Content | ConvertFrom-Json
             return $(New-SupportAssistGroupFromJson -Group $GroupData)
         }

--- a/DellOpenManage/Public/OME/Get-OMESupportAssistGroup.ps1
+++ b/DellOpenManage/Public/OME/Get-OMESupportAssistGroup.ps1
@@ -62,7 +62,7 @@ Process {
 
         $GroupData = @()
         $GrpResp = Invoke-WebRequest -Uri $GroupUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $ContentType
-        if ($GrpResp.StatusCode -eq 200) {
+        if ($GrpResp.StatusCode -in (200,201)) {
             $GroupData = $GrpResp.Content | ConvertFrom-Json
             return $(New-SupportAssistGroupFromJson -Group $GroupData)
         }

--- a/DellOpenManage/Public/OME/Get-OMETemplate.ps1
+++ b/DellOpenManage/Public/OME/Get-OMETemplate.ps1
@@ -94,7 +94,7 @@ Process {
         }
         $TemplateData = @()
         $TemplateResp = Invoke-WebRequest -Uri $TemplateUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($TemplateResp.StatusCode -eq 200) {
+        if ($TemplateResp.StatusCode -in (200,201)) {
             $TemplateInfo = $TemplateResp.Content | ConvertFrom-Json
             if ($TemplateInfo.'value'.Length -gt 0) {
                 foreach ($TemplateJson in $TemplateInfo.'value') {

--- a/DellOpenManage/Public/OME/Get-OMETemplate.ps1
+++ b/DellOpenManage/Public/OME/Get-OMETemplate.ps1
@@ -94,7 +94,7 @@ Process {
         }
         $TemplateData = @()
         $TemplateResp = Invoke-WebRequest -Uri $TemplateUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($TemplateResp.StatusCode -in (200,201)) {
+        if ($TemplateResp.StatusCode -in 200, 201) {
             $TemplateInfo = $TemplateResp.Content | ConvertFrom-Json
             if ($TemplateInfo.'value'.Length -gt 0) {
                 foreach ($TemplateJson in $TemplateInfo.'value') {

--- a/DellOpenManage/Public/OME/Get-OMETemplateNetwork.ps1
+++ b/DellOpenManage/Public/OME/Get-OMETemplateNetwork.ps1
@@ -53,7 +53,7 @@ function Get-OMETemplateNetwork {
             $TemplateVlanUrl = $BaseUri + "/api/TemplateService/Templates($($Template.Id))/Views(4)/AttributeViewDetails"
             Write-Verbose $TemplateVlanUrl
             $TemplateVlanResponse = Invoke-WebRequest -UseBasicParsing -Uri $TemplateVlanUrl -Headers $Headers -Method Get -ContentType $ContentType
-            if ($TemplateVlanResponse.StatusCode -in (200,201)) {
+            if ($TemplateVlanResponse.StatusCode -in 200, 201) {
                 $TemplateVlanInfo = $TemplateVlanResponse.Content | ConvertFrom-Json
                 $AttributeGroups = $TemplateVlanInfo.AttributeGroups
                 $PortVlanInfo = @()

--- a/DellOpenManage/Public/OME/Get-OMETemplateNetwork.ps1
+++ b/DellOpenManage/Public/OME/Get-OMETemplateNetwork.ps1
@@ -53,7 +53,7 @@ function Get-OMETemplateNetwork {
             $TemplateVlanUrl = $BaseUri + "/api/TemplateService/Templates($($Template.Id))/Views(4)/AttributeViewDetails"
             Write-Verbose $TemplateVlanUrl
             $TemplateVlanResponse = Invoke-WebRequest -UseBasicParsing -Uri $TemplateVlanUrl -Headers $Headers -Method Get -ContentType $ContentType
-            if ($TemplateVlanResponse.StatusCode -eq 200) {
+            if ($TemplateVlanResponse.StatusCode -in (200,201)) {
                 $TemplateVlanInfo = $TemplateVlanResponse.Content | ConvertFrom-Json
                 $AttributeGroups = $TemplateVlanInfo.AttributeGroups
                 $PortVlanInfo = @()

--- a/DellOpenManage/Public/OME/Get-OMEUser.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEUser.ps1
@@ -77,7 +77,7 @@ Process {
 
         $AccountData = @()
         $AccountResponse = Invoke-WebRequest -UseBasicParsing -Uri $AccountUrl -Headers $Headers -Method Get
-        if ($AccountResponse.StatusCode -eq 200) {
+        if ($AccountResponse.StatusCode -in (200,201)) {
             $AccountInfo = $AccountResponse.Content | ConvertFrom-Json
             if ($AccountInfo.value) { 
                 foreach ($AccountValue in $AccountInfo.value) {
@@ -88,7 +88,7 @@ Process {
                 }
                 while($NextLinkUrl) {
                     $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                    if($NextLinkResponse.StatusCode -eq 200)
+                    if($NextLinkResponse.StatusCode -in (200,201))
                     {
                         $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                         foreach ($NextLinkAccount in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Get-OMEUser.ps1
+++ b/DellOpenManage/Public/OME/Get-OMEUser.ps1
@@ -77,7 +77,7 @@ Process {
 
         $AccountData = @()
         $AccountResponse = Invoke-WebRequest -UseBasicParsing -Uri $AccountUrl -Headers $Headers -Method Get
-        if ($AccountResponse.StatusCode -in (200,201)) {
+        if ($AccountResponse.StatusCode -in 200, 201) {
             $AccountInfo = $AccountResponse.Content | ConvertFrom-Json
             if ($AccountInfo.value) { 
                 foreach ($AccountValue in $AccountInfo.value) {
@@ -88,7 +88,7 @@ Process {
                 }
                 while($NextLinkUrl) {
                     $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                    if($NextLinkResponse.StatusCode -in (200,201))
+                    if($NextLinkResponse.StatusCode -in 200, 201)
                     {
                         $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                         foreach ($NextLinkAccount in $NextLinkData.'value') {

--- a/DellOpenManage/Public/OME/Invoke-OMEConfigurationBaselineRefresh.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEConfigurationBaselineRefresh.ps1
@@ -103,7 +103,7 @@ Process {
         $BaselinePayload = $BaselinePayload | ConvertTo-Json -Depth 6
         Write-Verbose $BaselinePayload
         $BaselineResponse = Invoke-WebRequest -Uri $BaselineURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method PUT -Body $BaselinePayload
-        if ($BaselineResponse.StatusCode -eq 200) {
+        if ($BaselineResponse.StatusCode -in (200,201)) {
             $BaselineData = $BaselineResponse.Content | ConvertFrom-Json
             Write-Verbose $BaselineData
             if ($Wait) {

--- a/DellOpenManage/Public/OME/Invoke-OMEConfigurationBaselineRefresh.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEConfigurationBaselineRefresh.ps1
@@ -103,7 +103,7 @@ Process {
         $BaselinePayload = $BaselinePayload | ConvertTo-Json -Depth 6
         Write-Verbose $BaselinePayload
         $BaselineResponse = Invoke-WebRequest -Uri $BaselineURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method PUT -Body $BaselinePayload
-        if ($BaselineResponse.StatusCode -in (200,201)) {
+        if ($BaselineResponse.StatusCode -in 200, 201) {
             $BaselineData = $BaselineResponse.Content | ConvertFrom-Json
             Write-Verbose $BaselineData
             if ($Wait) {

--- a/DellOpenManage/Public/OME/Invoke-OMEMcmGroupAddMember.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEMcmGroupAddMember.ps1
@@ -47,7 +47,7 @@ function Invoke-OMEMcmGroupAddMember {
         $TargetArray = @()
         $URL = $BaseUri + "/api/ManagementDomainService/DiscoveredDomains"
         $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method GET
-        if ($Response.StatusCode -in (200,201)) {
+        if ($Response.StatusCode -in 200, 201) {
             $DomainResp = $Response.Content | ConvertFrom-Json
             if ($DomainResp."value".Length -gt 0) {
                 $DiscoveredDomains = $DomainResp."value"
@@ -95,7 +95,7 @@ function Invoke-OMEMcmGroupAddMember {
             Write-Verbose "Adding members to the group..."
             Write-Verbose "Invoking URL $($ManagementDomainURL)"
             $Response = Invoke-WebRequest -Uri $ManagementDomainURL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $Body 
-            if ($Response.StatusCode -in (200,201)) {
+            if ($Response.StatusCode -in 200, 201) {
                 $ManagementData = $Response | ConvertFrom-Json
                 $JobId = $ManagementData.'JobId'
                 Write-Verbose "Added members to the created group...Job ID is $($JobId)"

--- a/DellOpenManage/Public/OME/Invoke-OMEMcmGroupAddMember.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEMcmGroupAddMember.ps1
@@ -47,7 +47,7 @@ function Invoke-OMEMcmGroupAddMember {
         $TargetArray = @()
         $URL = $BaseUri + "/api/ManagementDomainService/DiscoveredDomains"
         $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method GET
-        if ($Response.StatusCode -eq 200) {
+        if ($Response.StatusCode -in (200,201)) {
             $DomainResp = $Response.Content | ConvertFrom-Json
             if ($DomainResp."value".Length -gt 0) {
                 $DiscoveredDomains = $DomainResp."value"
@@ -95,7 +95,7 @@ function Invoke-OMEMcmGroupAddMember {
             Write-Verbose "Adding members to the group..."
             Write-Verbose "Invoking URL $($ManagementDomainURL)"
             $Response = Invoke-WebRequest -Uri $ManagementDomainURL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $Body 
-            if ($Response.StatusCode -eq 200) {
+            if ($Response.StatusCode -in (200,201)) {
                 $ManagementData = $Response | ConvertFrom-Json
                 $JobId = $ManagementData.'JobId'
                 Write-Verbose "Added members to the created group...Job ID is $($JobId)"

--- a/DellOpenManage/Public/OME/Invoke-OMEMcmGroupAssignBackupLead.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEMcmGroupAssignBackupLead.ps1
@@ -74,7 +74,7 @@ function Invoke-OMEMcmGroupAssignBackupLead {
             Write-Verbose "Invoking URL $($URL)"
             Write-Verbose "Payload $($Body)"
             $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $Body 
-            if ($Response.StatusCode -in (200,201)) {
+            if ($Response.StatusCode -in 200, 201) {
                 $BackupLeadData = $Response | ConvertFrom-Json
                 $JobId = $BackupLeadData.'JobId'
                 Write-Verbose "Successfully assigned backup lead"

--- a/DellOpenManage/Public/OME/Invoke-OMEMcmGroupAssignBackupLead.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEMcmGroupAssignBackupLead.ps1
@@ -74,7 +74,7 @@ function Invoke-OMEMcmGroupAssignBackupLead {
             Write-Verbose "Invoking URL $($URL)"
             Write-Verbose "Payload $($Body)"
             $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $Body 
-            if ($Response.StatusCode -eq 200) {
+            if ($Response.StatusCode -in (200,201)) {
                 $BackupLeadData = $Response | ConvertFrom-Json
                 $JobId = $BackupLeadData.'JobId'
                 Write-Verbose "Successfully assigned backup lead"

--- a/DellOpenManage/Public/OME/Invoke-OMEMcmGroupRetireLead.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEMcmGroupRetireLead.ps1
@@ -30,7 +30,7 @@ function Invoke-RetireLead($BaseUri, $Headers, $ContentType, $PostRetirementRole
     $Body = $Payload | ConvertTo-Json -Depth 6
     Write-Verbose $Body
     $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $Body 
-    if ($Response.StatusCode -in (200,201)) {
+    if ($Response.StatusCode -in 200, 201) {
         $RetireLeadResp = $Response | ConvertFrom-Json
         $JobId = $RetireLeadResp.'JobId'
         if ($JobId) {

--- a/DellOpenManage/Public/OME/Invoke-OMEMcmGroupRetireLead.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEMcmGroupRetireLead.ps1
@@ -30,7 +30,7 @@ function Invoke-RetireLead($BaseUri, $Headers, $ContentType, $PostRetirementRole
     $Body = $Payload | ConvertTo-Json -Depth 6
     Write-Verbose $Body
     $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $Body 
-    if ($Response.StatusCode -eq 200) {
+    if ($Response.StatusCode -in (200,201)) {
         $RetireLeadResp = $Response | ConvertFrom-Json
         $JobId = $RetireLeadResp.'JobId'
         if ($JobId) {

--- a/DellOpenManage/Public/OME/Invoke-OMEProfileAssign.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEProfileAssign.ps1
@@ -173,7 +173,7 @@ Process {
         $ProfileAssignPayload = $ProfileAssignPayload |ConvertTo-Json -Depth 6
         Write-Verbose $ProfileAssignPayload
         $ProfileAssignResponse = Invoke-WebRequest -Uri $ProfileAssignUrl -UseBasicParsing -Method Post -Body $ProfileAssignPayload -ContentType $Type -Headers $Headers
-        if ($ProfileAssignResponse.StatusCode -in (200,201)) {
+        if ($ProfileAssignResponse.StatusCode -in 200, 201) {
             $ProfileAssignContent = $ProfileAssignResponse.Content | ConvertFrom-Json
             $JobId = $ProfileAssignContent
             if ($JobId -ne 0) {

--- a/DellOpenManage/Public/OME/Invoke-OMEProfileAssign.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEProfileAssign.ps1
@@ -173,7 +173,7 @@ Process {
         $ProfileAssignPayload = $ProfileAssignPayload |ConvertTo-Json -Depth 6
         Write-Verbose $ProfileAssignPayload
         $ProfileAssignResponse = Invoke-WebRequest -Uri $ProfileAssignUrl -UseBasicParsing -Method Post -Body $ProfileAssignPayload -ContentType $Type -Headers $Headers
-        if ($ProfileAssignResponse.StatusCode -eq 200) {
+        if ($ProfileAssignResponse.StatusCode -in (200,201)) {
             $ProfileAssignContent = $ProfileAssignResponse.Content | ConvertFrom-Json
             $JobId = $ProfileAssignContent
             if ($JobId -ne 0) {

--- a/DellOpenManage/Public/OME/Invoke-OMEProfileRename.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEProfileRename.ps1
@@ -69,7 +69,7 @@ Process {
         $ProfileRenamePayload = $Payload | ConvertTo-Json -Depth 6
         Write-Verbose $ProfileRenamePayload
         $JobResponse = Invoke-WebRequest -Uri $ProfileRenameURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $ProfileRenamePayload
-        if ($JobResponse.StatusCode -in (200,201)) {
+        if ($JobResponse.StatusCode -in 200, 201) {
             return "Completed"
             Write-Verbose "Job run successful..."
         }

--- a/DellOpenManage/Public/OME/Invoke-OMEProfileRename.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEProfileRename.ps1
@@ -69,7 +69,7 @@ Process {
         $ProfileRenamePayload = $Payload | ConvertTo-Json -Depth 6
         Write-Verbose $ProfileRenamePayload
         $JobResponse = Invoke-WebRequest -Uri $ProfileRenameURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $ProfileRenamePayload
-        if ($JobResponse.StatusCode -eq 200) {
+        if ($JobResponse.StatusCode -in (200,201)) {
             return "Completed"
             Write-Verbose "Job run successful..."
         }

--- a/DellOpenManage/Public/OME/Invoke-OMEProfileUnassign.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEProfileUnassign.ps1
@@ -115,7 +115,7 @@ Process {
         Write-Verbose $ProfileUnassignPayload
         Try { # Workaround to capture 400 (Bad Request) error when trying to unassign profile without target device found
             $ProfileUnassignResponse = Invoke-WebRequest -Uri $ProfileUnassignUrl -UseBasicParsing -Method Post -Body $ProfileUnassignPayload -ContentType $Type -Headers $Headers
-            if ($ProfileUnassignResponse.StatusCode -in (200,201)) {
+            if ($ProfileUnassignResponse.StatusCode -in 200, 201) {
                 $ProfileUnassignContent = $ProfileUnassignResponse.Content | ConvertFrom-Json
                 $JobId = $ProfileUnassignContent
                 if ($JobId -ne 0) {

--- a/DellOpenManage/Public/OME/Invoke-OMEProfileUnassign.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEProfileUnassign.ps1
@@ -115,7 +115,7 @@ Process {
         Write-Verbose $ProfileUnassignPayload
         Try { # Workaround to capture 400 (Bad Request) error when trying to unassign profile without target device found
             $ProfileUnassignResponse = Invoke-WebRequest -Uri $ProfileUnassignUrl -UseBasicParsing -Method Post -Body $ProfileUnassignPayload -ContentType $Type -Headers $Headers
-            if ($ProfileUnassignResponse.StatusCode -eq 200) {
+            if ($ProfileUnassignResponse.StatusCode -in (200,201)) {
                 $ProfileUnassignContent = $ProfileUnassignResponse.Content | ConvertFrom-Json
                 $JobId = $ProfileUnassignContent
                 if ($JobId -ne 0) {

--- a/DellOpenManage/Public/OME/Invoke-OMEReport.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEReport.ps1
@@ -8,14 +8,14 @@
     $OutputArray = @()
     $ColumnNames = @()
     $DeetsResp = Invoke-WebRequest -Uri $ReportDeets -UseBasicParsing -Headers $Headers -Method Get -ContentType $Type
-    if ($DeetsResp.StatusCode -eq 200){
+    if ($DeetsResp.StatusCode -in (200,201)){
         $DeetsInfo = $DeetsResp.Content | ConvertFrom-Json
         $ColumnNames = $DeetsInfo.ResultRowColumns | ForEach-Object{$_.Name}
         Write-Verbose "Extracting results for report ($($ReportId))"
         $ResultUrl = $BaseUri + "/api/ReportService/ReportDefs($($ReportId))/ReportResults/ResultRows"
         
         $RepResult = Invoke-WebRequest -Uri $ResultUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($RepResult.StatusCode -eq 200) {
+        if ($RepResult.StatusCode -in (200,201)) {
             $RepInfo = $RepResult.Content | ConvertFrom-Json
             $totalRepResults = [int]($RepInfo.'@odata.count')
             if ($totalRepResults -gt 0) {
@@ -25,7 +25,7 @@
                 }
                 while ($NextLinkUrl){
                     $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                    if ($NextLinkResponse.StatusCode -eq 200) {
+                    if ($NextLinkResponse.StatusCode -in (200,201)) {
                         $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                         $ReportResultList += $NextLinkData.'value'
                         if ($NextLinkData.'@odata.nextLink'){
@@ -118,7 +118,7 @@ Process {
         Write-Verbose $RepPayload
         
         $ReportResp = Invoke-WebRequest -Uri $ExecRepUrl -UseBasicParsing -Method Post -Headers $Headers -ContentType $Type -Body $RepPayload
-        if ($ReportResp.StatusCode -eq 200) {
+        if ($ReportResp.StatusCode -in (200,201)) {
             $JobId = $ReportResp.Content
             $JobStatus = $($JobId | Wait-OnJob)
             if ($JobStatus -eq 'Completed') {

--- a/DellOpenManage/Public/OME/Invoke-OMEReport.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMEReport.ps1
@@ -8,14 +8,14 @@
     $OutputArray = @()
     $ColumnNames = @()
     $DeetsResp = Invoke-WebRequest -Uri $ReportDeets -UseBasicParsing -Headers $Headers -Method Get -ContentType $Type
-    if ($DeetsResp.StatusCode -in (200,201)){
+    if ($DeetsResp.StatusCode -in 200, 201){
         $DeetsInfo = $DeetsResp.Content | ConvertFrom-Json
         $ColumnNames = $DeetsInfo.ResultRowColumns | ForEach-Object{$_.Name}
         Write-Verbose "Extracting results for report ($($ReportId))"
         $ResultUrl = $BaseUri + "/api/ReportService/ReportDefs($($ReportId))/ReportResults/ResultRows"
         
         $RepResult = Invoke-WebRequest -Uri $ResultUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-        if ($RepResult.StatusCode -in (200,201)) {
+        if ($RepResult.StatusCode -in 200, 201) {
             $RepInfo = $RepResult.Content | ConvertFrom-Json
             $totalRepResults = [int]($RepInfo.'@odata.count')
             if ($totalRepResults -gt 0) {
@@ -25,7 +25,7 @@
                 }
                 while ($NextLinkUrl){
                     $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                    if ($NextLinkResponse.StatusCode -in (200,201)) {
+                    if ($NextLinkResponse.StatusCode -in 200, 201) {
                         $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                         $ReportResultList += $NextLinkData.'value'
                         if ($NextLinkData.'@odata.nextLink'){
@@ -118,7 +118,7 @@ Process {
         Write-Verbose $RepPayload
         
         $ReportResp = Invoke-WebRequest -Uri $ExecRepUrl -UseBasicParsing -Method Post -Headers $Headers -ContentType $Type -Body $RepPayload
-        if ($ReportResp.StatusCode -in (200,201)) {
+        if ($ReportResp.StatusCode -in 200, 201) {
             $JobId = $ReportResp.Content
             $JobStatus = $($JobId | Wait-OnJob)
             if ($JobStatus -eq 'Completed') {

--- a/DellOpenManage/Public/OME/Invoke-OMETemplateDeploy.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMETemplateDeploy.ps1
@@ -13,7 +13,7 @@ function Set-AssignedIdentity($BaseUri, $Type, $Headers, $TemplateId, $TargetIds
     $Payload.BaseEntityIds = $TargetIds
     $AssignedIdentitiesPayload = $Payload|ConvertTo-Json -Depth 6
     $AssignedIdentitiesResponse = Invoke-WebRequest -Uri $TemplateUrl -UseBasicParsing -Method Post -Body $AssignedIdentitiesPayload -ContentType $Type -Headers $Headers
-    if ( $AssignedIdentitiesResponse.StatusCode -eq 200) {
+    if ( $AssignedIdentitiesResponse.StatusCode -in (200,201)) {
         $AssignIdentitiesInfo = $AssignedIdentitiesResponse.Content | ConvertFrom-Json
         $AssignIdentitiesInfo = $AssignIdentitiesInfo |ConvertTo-Json -Depth 6
         Write-Verbose $AssignIdentitiesInfo
@@ -215,7 +215,7 @@ Process {
         #$AssignIdentityResponse = Set-IdentitiesToTarget $IpAddress $Type $Headers $IdentityPoolId $TemplateId
 
         $DeployTemplateResponse = Invoke-WebRequest -Uri $TemplateDeployUrl -UseBasicParsing -Method Post -Body $TemplateDeployPayload -ContentType $Type -Headers $Headers
-        if ($DeployTemplateResponse.StatusCode -eq 200) {
+        if ($DeployTemplateResponse.StatusCode -in (200,201)) {
             $DeployTemplateContent = $DeployTemplateResponse.Content | ConvertFrom-Json
             $JobId = $DeployTemplateContent
             if ($JobId -ne 0) {

--- a/DellOpenManage/Public/OME/Invoke-OMETemplateDeploy.ps1
+++ b/DellOpenManage/Public/OME/Invoke-OMETemplateDeploy.ps1
@@ -13,7 +13,7 @@ function Set-AssignedIdentity($BaseUri, $Type, $Headers, $TemplateId, $TargetIds
     $Payload.BaseEntityIds = $TargetIds
     $AssignedIdentitiesPayload = $Payload|ConvertTo-Json -Depth 6
     $AssignedIdentitiesResponse = Invoke-WebRequest -Uri $TemplateUrl -UseBasicParsing -Method Post -Body $AssignedIdentitiesPayload -ContentType $Type -Headers $Headers
-    if ( $AssignedIdentitiesResponse.StatusCode -in (200,201)) {
+    if ( $AssignedIdentitiesResponse.StatusCode -in 200, 201) {
         $AssignIdentitiesInfo = $AssignedIdentitiesResponse.Content | ConvertFrom-Json
         $AssignIdentitiesInfo = $AssignIdentitiesInfo |ConvertTo-Json -Depth 6
         Write-Verbose $AssignIdentitiesInfo
@@ -215,7 +215,7 @@ Process {
         #$AssignIdentityResponse = Set-IdentitiesToTarget $IpAddress $Type $Headers $IdentityPoolId $TemplateId
 
         $DeployTemplateResponse = Invoke-WebRequest -Uri $TemplateDeployUrl -UseBasicParsing -Method Post -Body $TemplateDeployPayload -ContentType $Type -Headers $Headers
-        if ($DeployTemplateResponse.StatusCode -in (200,201)) {
+        if ($DeployTemplateResponse.StatusCode -in 200, 201) {
             $DeployTemplateContent = $DeployTemplateResponse.Content | ConvertFrom-Json
             $JobId = $DeployTemplateContent
             if ($JobId -ne 0) {

--- a/DellOpenManage/Public/OME/New-OMEDiscovery.ps1
+++ b/DellOpenManage/Public/OME/New-OMEDiscovery.ps1
@@ -111,7 +111,7 @@ function Get-JobId($BaseUri, $Headers, $DiscoverConfigGroupId) {
     $JobId = -1
     $JobUrl = $BaseUri + "/api/DiscoveryConfigService/Jobs"
     $JobResponse = Invoke-WebRequest -UseBasicParsing -Uri $JobUrl -Headers $Headers -Method Get
-    if ($JobResponse.StatusCode -in (200,201)) {
+    if ($JobResponse.StatusCode -in 200, 201) {
         $JobInfo = $JobResponse.Content | ConvertFrom-Json
         $JobValues = $JobInfo.value
         foreach ($value in $JobValues) {

--- a/DellOpenManage/Public/OME/New-OMEDiscovery.ps1
+++ b/DellOpenManage/Public/OME/New-OMEDiscovery.ps1
@@ -111,7 +111,7 @@ function Get-JobId($BaseUri, $Headers, $DiscoverConfigGroupId) {
     $JobId = -1
     $JobUrl = $BaseUri + "/api/DiscoveryConfigService/Jobs"
     $JobResponse = Invoke-WebRequest -UseBasicParsing -Uri $JobUrl -Headers $Headers -Method Get
-    if ($JobResponse.StatusCode -eq 200) {
+    if ($JobResponse.StatusCode -in (200,201)) {
         $JobInfo = $JobResponse.Content | ConvertFrom-Json
         $JobValues = $JobInfo.value
         foreach ($value in $JobValues) {

--- a/DellOpenManage/Public/OME/New-OMEFabric.ps1
+++ b/DellOpenManage/Public/OME/New-OMEFabric.ps1
@@ -39,7 +39,7 @@ function Invoke-CheckOMEFabricApplicableNode ($BaseUri, $Headers, $ContentType, 
     Write-Verbose "Get fabric applicable nodes"
     Write-Verbose $ApplicableNodesURL
     $Response = Invoke-WebRequest -Uri $ApplicableNodesURL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $null
-    if ($Response.StatusCode -in (200,201)) {
+    if ($Response.StatusCode -in 200, 201) {
         $SwitchAPass = $false
         $SwitchBPass = $false
         $DesignCriteriaData = $Response | ConvertFrom-Json
@@ -157,7 +157,7 @@ Try {
     Write-Verbose $FabricPayload
     $CreateFabricURL = $BaseUri + "/api/NetworkService/Actions/NetworkService.CreateFabric"
     $Response = Invoke-WebRequest -Uri $CreateFabricURL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $FabricPayload 
-    if ($Response.StatusCode -in (200,201)) {
+    if ($Response.StatusCode -in 200, 201) {
         $FabricData = $Response | ConvertFrom-Json
         $JobId = $FabricData.JobId
         Write-Verbose "Create fabric job created successfully...JobId is $($JobId)"

--- a/DellOpenManage/Public/OME/New-OMEFabric.ps1
+++ b/DellOpenManage/Public/OME/New-OMEFabric.ps1
@@ -39,7 +39,7 @@ function Invoke-CheckOMEFabricApplicableNode ($BaseUri, $Headers, $ContentType, 
     Write-Verbose "Get fabric applicable nodes"
     Write-Verbose $ApplicableNodesURL
     $Response = Invoke-WebRequest -Uri $ApplicableNodesURL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $null
-    if ($Response.StatusCode -eq 200) {
+    if ($Response.StatusCode -in (200,201)) {
         $SwitchAPass = $false
         $SwitchBPass = $false
         $DesignCriteriaData = $Response | ConvertFrom-Json
@@ -157,7 +157,7 @@ Try {
     Write-Verbose $FabricPayload
     $CreateFabricURL = $BaseUri + "/api/NetworkService/Actions/NetworkService.CreateFabric"
     $Response = Invoke-WebRequest -Uri $CreateFabricURL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method POST -Body $FabricPayload 
-    if ($Response.StatusCode -eq 200) {
+    if ($Response.StatusCode -in (200,201)) {
         $FabricData = $Response | ConvertFrom-Json
         $JobId = $FabricData.JobId
         Write-Verbose "Create fabric job created successfully...JobId is $($JobId)"

--- a/DellOpenManage/Public/OME/New-OMEGroup.ps1
+++ b/DellOpenManage/Public/OME/New-OMEGroup.ps1
@@ -82,7 +82,7 @@ Process {
 
         $GroupResponse = Invoke-WebRequest -Uri $GroupURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $GroupPayload
         Write-Verbose "Creating Group..."
-        if ($GroupResponse.StatusCode -in (200,201)) {
+        if ($GroupResponse.StatusCode -in 200, 201) {
             return $GroupResponse.Content | ConvertFrom-Json
         }
         else {

--- a/DellOpenManage/Public/OME/New-OMEGroup.ps1
+++ b/DellOpenManage/Public/OME/New-OMEGroup.ps1
@@ -82,7 +82,7 @@ Process {
 
         $GroupResponse = Invoke-WebRequest -Uri $GroupURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $GroupPayload
         Write-Verbose "Creating Group..."
-        if ($GroupResponse.StatusCode -eq 200) {
+        if ($GroupResponse.StatusCode -in (200,201)) {
             return $GroupResponse.Content | ConvertFrom-Json
         }
         else {

--- a/DellOpenManage/Public/OME/New-OMEMcmGroup.ps1
+++ b/DellOpenManage/Public/OME/New-OMEMcmGroup.ps1
@@ -138,7 +138,7 @@ Try {
     Write-Verbose $McmGroupPayload
     $CreateGroupURL = $BaseUri + "/api/ManagementDomainService"
     $Response = Invoke-WebRequest -Uri $CreateGroupURL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method PUT -Body $McmGroupPayload 
-    if ($Response.StatusCode -in (200,201)) {
+    if ($Response.StatusCode -in 200, 201) {
         $GroupData = $Response | ConvertFrom-Json
         $JobId = $GroupData.JobId
         Write-Verbose "MCM group created successfully...JobId is $($JobId)"

--- a/DellOpenManage/Public/OME/New-OMEMcmGroup.ps1
+++ b/DellOpenManage/Public/OME/New-OMEMcmGroup.ps1
@@ -138,7 +138,7 @@ Try {
     Write-Verbose $McmGroupPayload
     $CreateGroupURL = $BaseUri + "/api/ManagementDomainService"
     $Response = Invoke-WebRequest -Uri $CreateGroupURL -UseBasicParsing -Headers $Headers -ContentType $ContentType -Method PUT -Body $McmGroupPayload 
-    if ($Response.StatusCode -eq 200) {
+    if ($Response.StatusCode -in (200,201)) {
         $GroupData = $Response | ConvertFrom-Json
         $JobId = $GroupData.JobId
         Write-Verbose "MCM group created successfully...JobId is $($JobId)"

--- a/DellOpenManage/Public/OME/New-OMETemplateFromFile.ps1
+++ b/DellOpenManage/Public/OME/New-OMETemplateFromFile.ps1
@@ -98,7 +98,7 @@ Process {
         $TemplateId = $null
         $TemplateResponse = Invoke-WebRequest -Uri $TemplateUrl -UseBasicParsing -Method Post -Body $TemplatePayload -ContentType $Type -Headers $Headers
         Write-Verbose "Creating Template..."
-        if ($TemplateResponse.StatusCode -eq 200) {
+        if ($TemplateResponse.StatusCode -in (200,201)) {
             $TemplateId = $TemplateResponse.Content | ConvertFrom-Json
             if ($Wait) {
                 $TemplateStatus = $($TemplateId | Wait-OnTemplate -WaitTime $WaitTime)

--- a/DellOpenManage/Public/OME/New-OMETemplateFromFile.ps1
+++ b/DellOpenManage/Public/OME/New-OMETemplateFromFile.ps1
@@ -98,7 +98,7 @@ Process {
         $TemplateId = $null
         $TemplateResponse = Invoke-WebRequest -Uri $TemplateUrl -UseBasicParsing -Method Post -Body $TemplatePayload -ContentType $Type -Headers $Headers
         Write-Verbose "Creating Template..."
-        if ($TemplateResponse.StatusCode -in (200,201)) {
+        if ($TemplateResponse.StatusCode -in 200, 201) {
             $TemplateId = $TemplateResponse.Content | ConvertFrom-Json
             if ($Wait) {
                 $TemplateStatus = $($TemplateId | Wait-OnTemplate -WaitTime $WaitTime)

--- a/DellOpenManage/Public/OME/Set-OMEApplicationSettings.ps1
+++ b/DellOpenManage/Public/OME/Set-OMEApplicationSettings.ps1
@@ -80,7 +80,7 @@ limitations under the License.
             $JobPayload = $JobPayload | ConvertTo-Json -Depth 6
             Write-Verbose $JobPayload
             $JobResp = Invoke-WebRequest -Uri $JobURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $JobPayload
-            if ($JobResp.StatusCode -eq 200) {
+            if ($JobResp.StatusCode -in (200,201)) {
                 Write-Verbose "Application settings job submitted successful..."
                 $JobInfo = $JobResp.Content | ConvertFrom-Json
                 $JobId = $JobInfo.JobId

--- a/DellOpenManage/Public/OME/Set-OMEApplicationSettings.ps1
+++ b/DellOpenManage/Public/OME/Set-OMEApplicationSettings.ps1
@@ -80,7 +80,7 @@ limitations under the License.
             $JobPayload = $JobPayload | ConvertTo-Json -Depth 6
             Write-Verbose $JobPayload
             $JobResp = Invoke-WebRequest -Uri $JobURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $JobPayload
-            if ($JobResp.StatusCode -in (200,201)) {
+            if ($JobResp.StatusCode -in 200, 201) {
                 Write-Verbose "Application settings job submitted successful..."
                 $JobInfo = $JobResp.Content | ConvertFrom-Json
                 $JobId = $JobInfo.JobId

--- a/DellOpenManage/Public/OME/Set-OMEPowerState.ps1
+++ b/DellOpenManage/Public/OME/Set-OMEPowerState.ps1
@@ -12,7 +12,7 @@ function Get-DevicePowerState($BaseUri, $Headers, $Type, $DeviceId) {
     $DeviceUrl = $BaseUri + "/api/DeviceService/Devices($($DeviceId))"
     $DevResp = Invoke-WebRequest -Uri $DeviceUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
     $PowerState = $null
-    if ($DevResp.StatusCode -eq 200){
+    if ($DevResp.StatusCode -in (200,201)){
         $DevInfo = $DevResp.Content | ConvertFrom-Json
         $PowerState = $DevInfo.PowerState
     }

--- a/DellOpenManage/Public/OME/Set-OMEPowerState.ps1
+++ b/DellOpenManage/Public/OME/Set-OMEPowerState.ps1
@@ -12,7 +12,7 @@ function Get-DevicePowerState($BaseUri, $Headers, $Type, $DeviceId) {
     $DeviceUrl = $BaseUri + "/api/DeviceService/Devices($($DeviceId))"
     $DevResp = Invoke-WebRequest -Uri $DeviceUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
     $PowerState = $null
-    if ($DevResp.StatusCode -in (200,201)){
+    if ($DevResp.StatusCode -in 200, 201){
         $DevInfo = $DevResp.Content | ConvertFrom-Json
         $PowerState = $DevInfo.PowerState
     }

--- a/DellOpenManage/Public/OME/Update-OMEFirmwareDUP.ps1
+++ b/DellOpenManage/Public/OME/Update-OMEFirmwareDUP.ps1
@@ -81,7 +81,7 @@ function Get-ApplicableComponent($BaseUri, $Headers, $ContentType, $DupReportPay
     $DupReportUrl = $BaseUri + "/api/UpdateService/Actions/UpdateService.GetSingleDupReport"
     try {
         $DupResponse = Invoke-WebRequest -Uri $DupReportUrl -UseBasicParsing -Headers $Headers -ContentType $ContentType -Body $DupReportPayload -Method Post -ErrorAction SilentlyContinue       
-        if ($DupResponse.StatusCode -eq 200) {
+        if ($DupResponse.StatusCode -in (200,201)) {
             $DupResponseInfo = $DupResponse.Content | ConvertFrom-Json
             if ($DupResponse.Length -gt 0) {
                 if ($DupResponseInfo.Length -gt 0) {
@@ -148,7 +148,7 @@ function Push-DupToOME($BaseUri, $Headers, $DupFile) {
     Write-Verbose "Uploading $($DupFile) to $($BaseUri). This action may take some time to complete."
     
     $UploadResponse = Invoke-WebRequest -Uri $UploadActionUri -UseBasicParsing -Method Post -InFile $DupFile -ContentType "application/octet-stream" -Headers $Headers
-    if ($UploadResponse.StatusCode -eq 200) {
+    if ($UploadResponse.StatusCode -in (200,201)) {
         ## Successfully uploaded the DUP file . Get the file token
         ## returned by OME on upload of the DUP file
         ## The file token is returned as an array of decimals that maps to ascii text values

--- a/DellOpenManage/Public/OME/Update-OMEFirmwareDUP.ps1
+++ b/DellOpenManage/Public/OME/Update-OMEFirmwareDUP.ps1
@@ -81,7 +81,7 @@ function Get-ApplicableComponent($BaseUri, $Headers, $ContentType, $DupReportPay
     $DupReportUrl = $BaseUri + "/api/UpdateService/Actions/UpdateService.GetSingleDupReport"
     try {
         $DupResponse = Invoke-WebRequest -Uri $DupReportUrl -UseBasicParsing -Headers $Headers -ContentType $ContentType -Body $DupReportPayload -Method Post -ErrorAction SilentlyContinue       
-        if ($DupResponse.StatusCode -in (200,201)) {
+        if ($DupResponse.StatusCode -in 200, 201) {
             $DupResponseInfo = $DupResponse.Content | ConvertFrom-Json
             if ($DupResponse.Length -gt 0) {
                 if ($DupResponseInfo.Length -gt 0) {
@@ -148,7 +148,7 @@ function Push-DupToOME($BaseUri, $Headers, $DupFile) {
     Write-Verbose "Uploading $($DupFile) to $($BaseUri). This action may take some time to complete."
     
     $UploadResponse = Invoke-WebRequest -Uri $UploadActionUri -UseBasicParsing -Method Post -InFile $DupFile -ContentType "application/octet-stream" -Headers $Headers
-    if ($UploadResponse.StatusCode -in (200,201)) {
+    if ($UploadResponse.StatusCode -in 200, 201) {
         ## Successfully uploaded the DUP file . Get the file token
         ## returned by OME on upload of the DUP file
         ## The file token is returned as an array of decimals that maps to ascii text values


### PR DESCRIPTION
 We found the OME scripts were all failing when a network redirect was performed, even if the requests were successful.
 
This network redirect was something we could not avoid in our hypervisor-hosted OME install.  In order to prove things were working, we relied on curl commands obtained by monitoring the OME portal. The curl commands returned '201' rather than the 200 the OME scripts expected. 

I am currently testing these changes. 